### PR TITLE
Fixes #3 - Allow uses in hosts other than WebHost.CreateDefaultBuilder()

### DIFF
--- a/Aqovia.PactProducerVerifier/PactProducerTests.cs
+++ b/Aqovia.PactProducerVerifier/PactProducerTests.cs
@@ -79,7 +79,7 @@ namespace Aqovia.PactProducerVerifier.AspNetCore
 
             var customStartup = new TestStartup(_configuration.AspNetCoreStartup, _configuration.StartupAssemblyLocation, _onWebAppStarting);
 
-            using (var host = WebHost.CreateDefaultBuilder()
+            using (var host = _configuration.GetBaseWebHostBuilder()
                 .ConfigureServices(services =>
                 {
                     services.AddSingleton<IStartup>(customStartup);                    

--- a/Aqovia.PactProducerVerifier/ProducerVerifierConfiguration.cs
+++ b/Aqovia.PactProducerVerifier/ProducerVerifierConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.AspNetCore.Hosting;
 
 namespace Aqovia.PactProducerVerifier.AspNetCore
 {
@@ -8,6 +9,7 @@ namespace Aqovia.PactProducerVerifier.AspNetCore
         public string PactBrokerUsername { get; set; }
         public string PactBrokerPassword { get; set; }
         public string PactBrokerUri { get; set; }
+        public Func<IWebHostBuilder> GetBaseWebHostBuilder { get; set; } = Microsoft.AspNetCore.WebHost.CreateDefaultBuilder;
         public Type AspNetCoreStartup { get; set; }
         public string StartupAssemblyLocation { get; set; }
     }


### PR DESCRIPTION
Fix #3 by exposing a way to change base IWebHostBuilder via `ProducerVerifierConfiguration` (keep default of `WebHost.CreateDefaultBuilder()`)
  