### PR TITLE
Added ProviderVersion param and used it to publish verifiaction resul…

### DIFF
--- a/Aqovia.PactProducerVerifier/PactProducerTests.cs
+++ b/Aqovia.PactProducerVerifier/PactProducerTests.cs
@@ -182,7 +182,9 @@ namespace Aqovia.PactProducerVerifier.AspNetCore
                 Outputters = new List<IOutput>
                 {
                     _output
-                }
+                },
+                ProviderVersion = !string.IsNullOrEmpty(_configuration.ProviderVersion) ? _configuration.ProviderVersion : null,
+                PublishVerificationResults = !string.IsNullOrEmpty(_configuration.ProviderVersion)
             };
 
             PactUriOptions pactUriOptions = null;

--- a/Aqovia.PactProducerVerifier/ProducerVerifierConfiguration.cs
+++ b/Aqovia.PactProducerVerifier/ProducerVerifierConfiguration.cs
@@ -5,11 +5,33 @@ namespace Aqovia.PactProducerVerifier.AspNetCore
 {
     public class ProducerVerifierConfiguration
     {
-        public string ProviderName { get; set; }        
+        /// <summary>
+        /// The name of the provider
+        /// </summary>
+        public string ProviderName { get; set; }
+        /// <summary>
+        /// If provider version is set the verifiaction results will be publishe to the Pact Broker
+        /// </summary>
+        public string ProviderVersion { get; set; }
+        /// <summary>
+        /// Username required to authenticate with the Pact Broker 
+        /// </summary>
         public string PactBrokerUsername { get; set; }
+        /// <summary>
+        /// Password required to authenticate with the Pact Broker
+        /// </summary>
         public string PactBrokerPassword { get; set; }
+        /// <summary>
+        /// The Pact Broker uri
+        /// </summary>
         public string PactBrokerUri { get; set; }
+        /// <summary>
+        /// Web hos builder defaulted to <c>Microsoft.AspNetCore.WebHost.CreateDefaultBuilder</c>
+        /// </summary>
         public Func<IWebHostBuilder> GetBaseWebHostBuilder { get; set; } = Microsoft.AspNetCore.WebHost.CreateDefaultBuilder;
+        /// <summary>
+        /// The type of the startup class to use when hosting the web application
+        /// </summary>
         public Type AspNetCoreStartup { get; set; }        
     }
 }


### PR DESCRIPTION
With the new version of Pact Broker is possible to publish provider verification results to the broker so that it's easy to see which provider version is compatible with a specific consumer contract

https://github.com/pact-foundation/pact_broker/wiki/Provider-verification-results

Can be used in conjunction with can-i-deploy command to verify if the consumer is compatible with a tagged version of the provider

https://github.com/pact-foundation/pact_broker-client#can-i-deploy 